### PR TITLE
feat: support displaying externally downloaded subtitles

### DIFF
--- a/core/src/main/java/com/jellycine/player/core/PlayerTrack.kt
+++ b/core/src/main/java/com/jellycine/player/core/PlayerTrack.kt
@@ -48,12 +48,27 @@ object PlayerTrack {
                 ?: selected.copy(streamIndex = null)
         }
 
-        var subtitleOrdinal = 0
+        val usedStreamIndexes = mutableSetOf<Int>()
         val apiNamedSubtitleTracks = liveSubtitleTracks.map { track ->
             if (track.streamIndex == -1 || track.id == "off") {
                 track.copy(streamIndex = -1)
             } else {
-                val stream = subtitleStreams.getOrNull(subtitleOrdinal++)
+                // try to find a matching stream by label and language first
+                val matchingStream = subtitleStreams.firstOrNull { stream ->
+                    val streamLabel = stream.displayTitleOrNull()
+                    val streamLang = stream.language?.take(2)?.lowercase()
+                    val trackLang = track.language?.take(2)?.lowercase()
+
+                    (streamLabel != null && streamLabel.equals(track.label, ignoreCase = true)) ||
+                        (streamLang != null && streamLang == trackLang)
+                }?.takeIf { it.index !in usedStreamIndexes }
+
+                val stream = matchingStream ?: subtitleStreams.firstOrNull { it.index !in usedStreamIndexes }
+                
+                if (stream != null) {
+                    usedStreamIndexes.add(stream.index!!)
+                }
+
                 track.copy(
                     label = stream?.displayTitleOrNull() ?: track.label,
                     streamIndex = stream?.index
@@ -95,6 +110,7 @@ object PlayerTrack {
                 language = null,
                 isForced = false,
                 isDefault = false,
+                playerTrackId = "subtitle:$streamIndex", // set ID so it can be identified, even if not yet in player
                 streamIndex = streamIndex,
                 requiresPlaybackRestart = true
             )
@@ -168,8 +184,15 @@ object PlayerTrack {
             }
         }
 
-        return (itemStreams + playbackStreams)
-            .distinctBy { "${it.type.orEmpty().lowercase(Locale.US)}:${it.index ?: "na"}" }
+        // Merge streams, prioritizing those with delivery information
+        val allStreams = playbackStreams + itemStreams
+        return allStreams
+            .groupBy { "${it.type.orEmpty().lowercase(Locale.US)}:${it.index ?: "na"}" }
+            .map { (_, group) ->
+                group.firstOrNull { !it.deliveryUrl.isNullOrBlank() }
+                    ?: group.firstOrNull { it.deliveryMethod != null }
+                    ?: group.first()
+            }
     }
 
     private fun indexedStreams(

--- a/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerStreamingMediaItemFactory.kt
+++ b/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerStreamingMediaItemFactory.kt
@@ -4,11 +4,15 @@ import android.net.Uri
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
 import com.jellycine.data.model.MediaStream
 import java.net.URI
 
+@UnstableApi
 internal fun streamingMediaItem(
     streamingUrl: String,
+    itemId: String? = null,
+    mediaSourceId: String? = null,
     selectedSubtitleStream: MediaStream? = null
 ): MediaItem {
     val streamUri = Uri.parse(streamingUrl)
@@ -18,17 +22,23 @@ internal fun streamingMediaItem(
 
     streamCacheKey(streamUri)?.let(builder::setCustomCacheKey)
 
-    selectedSubtitleStream
-        ?.takeIf { it.deliveryMethod.equals("External", ignoreCase = true) }
-        ?.let { subtitleStream ->
+    if (selectedSubtitleStream != null) {
+        val canDeliverExternally = selectedSubtitleStream.deliveryMethod.equals("External", ignoreCase = true) ||
+            !selectedSubtitleStream.deliveryUrl.isNullOrBlank() ||
+            selectedSubtitleStream.isExternal == true
+
+        if (canDeliverExternally) {
             val subtitleConfiguration = subtitleConfiguration(
                 streamingUrl = streamingUrl,
-                subtitleStream = subtitleStream
+                itemId = itemId,
+                mediaSourceId = mediaSourceId,
+                subtitleStream = selectedSubtitleStream
             )
             if (subtitleConfiguration != null) {
                 builder.setSubtitleConfigurations(listOf(subtitleConfiguration))
             }
         }
+    }
 
     return builder.build()
 }
@@ -76,19 +86,41 @@ private fun isHlsStreaming(streamUri: Uri): Boolean {
         normalizedUrl.contains("transcode")
 }
 
+@UnstableApi
 private fun subtitleConfiguration(
     streamingUrl: String,
+    itemId: String?,
+    mediaSourceId: String?,
     subtitleStream: MediaStream
 ): MediaItem.SubtitleConfiguration? {
-    val deliveryUrl = subtitleStream.deliveryUrl?.takeIf { it.isNotBlank() } ?: return null
+    var deliveryUrl = subtitleStream.deliveryUrl?.takeIf { it.isNotBlank() }
+
+    // if deliveryUrl is missing but it's an external subtitle, construct it using standard Jellyfin patterns
+    if (deliveryUrl == null && (subtitleStream.isExternal == true || subtitleStream.deliveryMethod.equals("External", ignoreCase = true)) && itemId != null) {
+        val codec = when (subtitleStream.codec?.lowercase()) {
+            "subrip", "srt" -> "srt"
+            "webvtt", "vtt" -> "vtt"
+            else -> subtitleStream.codec ?: "srt"
+        }
+        val index = subtitleStream.index ?: 0
+        
+        val sourceId = mediaSourceId ?: itemId
+        deliveryUrl = "Videos/$itemId/$sourceId/Subtitles/$index/0/Stream.$codec"
+    }
+
+    if (deliveryUrl == null) return null
+
     val resolvedUri = runCatching {
-        URI.create(streamingUrl).resolve(deliveryUrl).toString()
+        val baseUri = URI.create(streamingUrl)
+        "${baseUri.scheme}://${baseUri.authority}/${deliveryUrl.trimStart('/')}"
     }.getOrNull() ?: return null
+
+    val authorizedUri = authorizeUrl(resolvedUri, streamingUrl)
 
     val mimeType = subtitleMimeType(subtitleStream, deliveryUrl)
     val selectionFlags = subtitleSelectionFlags(subtitleStream)
 
-    return MediaItem.SubtitleConfiguration.Builder(Uri.parse(resolvedUri))
+    return MediaItem.SubtitleConfiguration.Builder(Uri.parse(authorizedUri))
         .setMimeType(mimeType)
         .setLanguage(subtitleStream.language)
         .setSelectionFlags(selectionFlags)
@@ -101,6 +133,34 @@ private fun subtitleConfiguration(
         .build()
 }
 
+private fun authorizeUrl(targetUrl: String, sourceUrl: String): String {
+    val targetUri = Uri.parse(targetUrl)
+    
+    val hasAuth = targetUri.queryParameterNames.any { 
+        it.equals("api_key", ignoreCase = true) || 
+        it.equals("ApiKey", ignoreCase = true) || 
+        it.equals("Token", ignoreCase = true) 
+    }
+    if (hasAuth) return targetUrl
+
+    val sourceUri = Uri.parse(sourceUrl)
+    
+    val authParam = sourceUri.queryParameterNames.firstOrNull { 
+        it.equals("api_key", ignoreCase = true) || 
+        it.equals("ApiKey", ignoreCase = true) || 
+        it.equals("Token", ignoreCase = true) 
+    }
+    
+    val authValue = authParam?.let { sourceUri.getQueryParameter(it) }
+
+    return if (authValue != null) {
+        targetUri.buildUpon().appendQueryParameter("ApiKey", authValue).build().toString()
+    } else {
+        targetUrl
+    }
+}
+
+@UnstableApi
 private fun subtitleMimeType(
     subtitleStream: MediaStream,
     deliveryUrl: String
@@ -130,6 +190,7 @@ private fun subtitleMimeType(
     }
 }
 
+@UnstableApi
 private fun subtitleSelectionFlags(subtitleStream: MediaStream): Int {
     var selectionFlags = 0
 

--- a/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerStreamingMediaItemFactory.kt
+++ b/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerStreamingMediaItemFactory.kt
@@ -1,6 +1,7 @@
 package com.jellycine.app.ui.screens.player
 
 import android.net.Uri
+import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
@@ -8,12 +9,15 @@ import androidx.media3.common.util.UnstableApi
 import com.jellycine.data.model.MediaStream
 import java.net.URI
 
+private const val TAG = "PlayerMediaItemFactory"
+
 @UnstableApi
 internal fun streamingMediaItem(
     streamingUrl: String,
     itemId: String? = null,
     mediaSourceId: String? = null,
-    selectedSubtitleStream: MediaStream? = null
+    selectedSubtitleStream: MediaStream? = null,
+    requestHeaders: Map<String, String> = emptyMap()
 ): MediaItem {
     val streamUri = Uri.parse(streamingUrl)
 
@@ -32,9 +36,11 @@ internal fun streamingMediaItem(
                 streamingUrl = streamingUrl,
                 itemId = itemId,
                 mediaSourceId = mediaSourceId,
-                subtitleStream = selectedSubtitleStream
+                subtitleStream = selectedSubtitleStream,
+                requestHeaders = requestHeaders
             )
             if (subtitleConfiguration != null) {
+                Log.d(TAG, "Adding external subtitle configuration: ${subtitleConfiguration.uri}")
                 builder.setSubtitleConfigurations(listOf(subtitleConfiguration))
             }
         }
@@ -91,31 +97,40 @@ private fun subtitleConfiguration(
     streamingUrl: String,
     itemId: String?,
     mediaSourceId: String?,
-    subtitleStream: MediaStream
+    subtitleStream: MediaStream,
+    requestHeaders: Map<String, String>
 ): MediaItem.SubtitleConfiguration? {
     var deliveryUrl = subtitleStream.deliveryUrl?.takeIf { it.isNotBlank() }
 
     // if deliveryUrl is missing but it's an external subtitle, construct it using standard Jellyfin patterns
     if (deliveryUrl == null && (subtitleStream.isExternal == true || subtitleStream.deliveryMethod.equals("External", ignoreCase = true)) && itemId != null) {
         val codec = when (subtitleStream.codec?.lowercase()) {
-            "subrip", "srt" -> "srt"
+            "subrip", "srt" -> "subrip" 
             "webvtt", "vtt" -> "vtt"
-            else -> subtitleStream.codec ?: "srt"
+            else -> "subrip"
         }
         val index = subtitleStream.index ?: 0
         
-        val sourceId = mediaSourceId ?: itemId
-        deliveryUrl = "Videos/$itemId/$sourceId/Subtitles/$index/0/Stream.$codec"
+        val guidItemId = itemId.toGuid()
+        val sourceId = mediaSourceId?.replace("-", "") ?: itemId.replace("-", "")
+        
+        deliveryUrl = "Videos/$guidItemId/$sourceId/Subtitles/$index/0/Stream.$codec"
+        Log.d(TAG, "Constructed delivery URL: $deliveryUrl")
     }
 
     if (deliveryUrl == null) return null
 
-    val resolvedUri = runCatching {
-        val baseUri = URI.create(streamingUrl)
-        "${baseUri.scheme}://${baseUri.authority}/${deliveryUrl.trimStart('/')}"
-    }.getOrNull() ?: return null
+    val resolvedUri = if (deliveryUrl.startsWith("http", ignoreCase = true)) {
+        deliveryUrl
+    } else {
+        runCatching {
+            val baseUri = URI.create(streamingUrl)
+            "${baseUri.scheme}://${baseUri.authority}/${deliveryUrl.trimStart('/')}"
+        }.getOrNull() ?: return null
+    }
 
-    val authorizedUri = authorizeUrl(resolvedUri, streamingUrl)
+    val authorizedUri = authorizeUrl(resolvedUri, streamingUrl, requestHeaders)
+    Log.d(TAG, "Resolved authorized subtitle URI: $authorizedUri")
 
     val mimeType = subtitleMimeType(subtitleStream, deliveryUrl)
     val selectionFlags = subtitleSelectionFlags(subtitleStream)
@@ -133,7 +148,21 @@ private fun subtitleConfiguration(
         .build()
 }
 
-private fun authorizeUrl(targetUrl: String, sourceUrl: String): String {
+private fun String.toGuid(): String {
+    if (this.contains("-") || this.length != 32) return this
+    return try {
+        StringBuilder(this)
+            .insert(8, "-")
+            .insert(13, "-")
+            .insert(18, "-")
+            .insert(23, "-")
+            .toString()
+    } catch (e: Exception) {
+        this
+    }
+}
+
+private fun authorizeUrl(targetUrl: String, sourceUrl: String, requestHeaders: Map<String, String>): String {
     val targetUri = Uri.parse(targetUrl)
     
     val hasAuth = targetUri.queryParameterNames.any { 
@@ -145,13 +174,24 @@ private fun authorizeUrl(targetUrl: String, sourceUrl: String): String {
 
     val sourceUri = Uri.parse(sourceUrl)
     
-    val authParam = sourceUri.queryParameterNames.firstOrNull { 
+    var authValue = sourceUri.queryParameterNames.firstOrNull { 
         it.equals("api_key", ignoreCase = true) || 
         it.equals("ApiKey", ignoreCase = true) || 
         it.equals("Token", ignoreCase = true) 
+    }?.let { sourceUri.getQueryParameter(it) }
+
+    if (authValue == null) {
+        val authHeader = requestHeaders["Authorization"] ?: requestHeaders["X-Emby-Authorization"]
+        if (authHeader != null) {
+            authValue = when {
+                authHeader.contains("Token=\"", ignoreCase = true) -> 
+                    authHeader.substringAfter("Token=\"").substringBefore("\"")
+                authHeader.contains("Token ", ignoreCase = true) -> 
+                    authHeader.substringAfter("Token ").trim()
+                else -> null
+            }
+        }
     }
-    
-    val authValue = authParam?.let { sourceUri.getQueryParameter(it) }
 
     return if (authValue != null) {
         targetUri.buildUpon().appendQueryParameter("ApiKey", authValue).build().toString()

--- a/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerTrackSelection.kt
+++ b/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerTrackSelection.kt
@@ -100,11 +100,11 @@ internal class PlayerTrackSelection {
                     it.streamIndex == preferredSubtitleIndex
                 }
                 val playerTrackId = subtitleTrack?.playerTrackId
-                if (playerTrackId != null) {
+                if (playerTrackId != null && !subtitleTrack.requiresPlaybackRestart) {
                     PlayerUtils.selectSubtitleTrack(player, playerTrackId)
                     subtitleHandled = true
                     appliedAnySelection = true
-                } else if (subtitleTrack != null) {
+                } else if (subtitleTrack?.requiresPlaybackRestart == true) {
                     subtitleHandled = true
                 }
             }

--- a/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerViewModel.kt
+++ b/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerViewModel.kt
@@ -379,7 +379,8 @@ class PlayerViewModel @Inject constructor(
                         streamingUrl = streamingUrl,
                         itemId = mediaId,
                         mediaSourceId = sessionMediaSourceId,
-                        selectedSubtitleStream = activeSubtitleStream
+                        selectedSubtitleStream = activeSubtitleStream,
+                        requestHeaders = playbackRequest?.requestHeaders.orEmpty()
                     )
                     if (!isMpvPlayback()) {
                         streamingMediaSource = PlayerUtils.createStreamingMediaSource(

--- a/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerViewModel.kt
+++ b/phone/src/main/java/com/jellycine/app/ui/screens/player/PlayerViewModel.kt
@@ -314,6 +314,12 @@ class PlayerViewModel @Inject constructor(
                     }
 
                     primaryMediaSource = playbackInfo.mediaSources?.firstOrNull()
+                    
+                    apiMediaStreams = PlayerTrack.resolveApiMediaStreams(
+                        itemDetails = itemDetails,
+                        playbackMediaSource = primaryMediaSource
+                    )
+                    
                     defaultAudioStreamIndex = primaryMediaSource?.defaultAudioStreamIndex
                     defaultSubtitleStreamIndex = primaryMediaSource?.defaultSubtitleStreamIndex
                     sessionPlaySessionId = playbackInfo.playSessionId
@@ -362,15 +368,17 @@ class PlayerViewModel @Inject constructor(
                         activePreferredSubtitleStreamIndex
                             ?: primaryMediaSource?.defaultSubtitleStreamIndex
                         )?.takeIf { it >= 0 }
-                    val activeSubtitleStream = primaryMediaSource
-                        ?.mediaStreams
+                    
+                    val activeSubtitleStream = apiMediaStreams
                         ?.firstOrNull { stream ->
-                            stream.type == "Subtitle" &&
+                            stream.type.equals("Subtitle", ignoreCase = true) &&
                                 stream.index == activeSubtitleStreamIndex
                         }
 
                     val streamingMediaItem = streamingMediaItem(
                         streamingUrl = streamingUrl,
+                        itemId = mediaId,
+                        mediaSourceId = sessionMediaSourceId,
                         selectedSubtitleStream = activeSubtitleStream
                     )
                     if (!isMpvPlayback()) {
@@ -394,11 +402,6 @@ class PlayerViewModel @Inject constructor(
                 )
                 playbackReporter.updateSession(playbackSession)
                 
-                // Get media info for spatial audio analysis
-                apiMediaStreams = PlayerTrack.resolveApiMediaStreams(
-                    itemDetails = itemDetails,
-                    playbackMediaSource = primaryMediaSource
-                )
                 mpvExternalSubtitleUrls = MPVPlayer.externalSubtitleUrls(
                     playbackRequest = playbackRequest,
                     mediaStreams = apiMediaStreams.orEmpty()
@@ -1149,8 +1152,18 @@ class PlayerViewModel @Inject constructor(
      * Select subtitle track by ID
      */
     fun selectSubtitleTrack(trackId: String) {
-        if (trackId == _playerState.value.currentSubtitleTrack?.id) return
-        val selectedTrack = _playerState.value.availableSubtitleTracks.firstOrNull { it.id == trackId } ?: return
+        Log.d(TAG, "Selecting subtitle track: $trackId")
+        if (trackId == _playerState.value.currentSubtitleTrack?.id) {
+            Log.d(TAG, "Subtitle track $trackId already selected")
+            return
+        }
+        val selectedTrack = _playerState.value.availableSubtitleTracks.firstOrNull { it.id == trackId } ?: run {
+            Log.w(TAG, "Could not find subtitle track with id $trackId in available tracks")
+            return
+        }
+        
+        Log.d(TAG, "Selected track info: label=${selectedTrack.label} streamIndex=${selectedTrack.streamIndex} requiresRestart=${selectedTrack.requiresPlaybackRestart}")
+
         if (isMpvPlayback()) {
             val streamIndex = MPVPlayer.selectSubtitleTrack(
                 controller = mpvPlayer,
@@ -1169,6 +1182,7 @@ class PlayerViewModel @Inject constructor(
             return
         }
         if (selectedTrack.requiresPlaybackRestart) {
+            Log.d(TAG, "Subtitle selection requires playback restart for stream index: ${selectedTrack.streamIndex}")
             playbackTrackSelection(
                 audioStreamIndex = _preferredStreamIndexes.value.audioStreamIndex,
                 subtitleStreamIndex = selectedTrack.streamIndex
@@ -1177,6 +1191,7 @@ class PlayerViewModel @Inject constructor(
         }
         exoPlayer?.let { player ->
             val playerTrackId = selectedTrack.playerTrackId ?: return
+            Log.d(TAG, "Applying subtitle selection to ExoPlayer: $playerTrackId")
             trackSelectionCoordinator.markManualTrackSelection()
             PlayerUtils.selectSubtitleTrack(player, playerTrackId)
             viewModelScope.launch {


### PR DESCRIPTION
**Fix subtitle visibility for OpenSubtitles plugin + dependency updates**

Subtitles downloaded via the OpenSubtitles plugin were not being displayed even after selecting them from the menu. 
This PR fixes the issue so that externally downloaded subtitles (via OpenSubtitles) now render correctly alongside local subtitle files.

_Also includes dependency updates to ensure the app compiles successfully._